### PR TITLE
Document additional auth providers.

### DIFF
--- a/blueprint/authentication.apib
+++ b/blueprint/authentication.apib
@@ -8,7 +8,9 @@ The Grid operates an OAuth2 provider that is utilized for all authentication pur
 ### Identity Providers
 The Grid's authentication system supports multiple identity providers including:
 
+* Facebook (facebook)
 * GitHub (github)
+* Google (google)
 * Twitter (twitter)
 
 More identity providers are likely to be added later when they are needed. Check back to this document to see the current list.


### PR DESCRIPTION
This pull request adds Facebook and Google to the list of authentication providers, and should close #31.
