### PR TITLE
Update HTTP status code for deleting an item.

### DIFF
--- a/blueprint/api.apib
+++ b/blueprint/api.apib
@@ -293,7 +293,7 @@ When an item is being worked on by a user it is available via the API.
 
 ### Remove item [DELETE]
 
-+ Response 204
++ Response 200
 
 ## Publishing [/publish]
 


### PR DESCRIPTION
I noticed that the HTTP status code for deleting a site was `200` while it was shown as `204` for deleting an item.

I tried deleting an item and got a `200` response, so it seems that the documentation was incorrect.
